### PR TITLE
Easing function as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ Defaults are shown below, explanation of each option follows.
 Jump.jump('.selector', {
   duration: /* REQUIRED, no default */,
   offset: 0,
-  callback: undefined
+  callback: undefined,
+  easing: (t, b, c, d) => {
+    // Robert Penner's easeInOutQuad - http://robertpenner.com/easing/
+    t /= d / 2
+    if(t < 1) return c / 2 * t * t + b
+    t--
+    return -c / 2 * (t * (t - 2) - 1) + b
+  }
 })
 ```
 
@@ -113,6 +120,18 @@ Fired after the `jump()` has been completed.
 Jump.jump('.selector', {
   callback: () => {
     console.log('Jump completed!')
+  }
+})
+```
+
+##### easing
+
+Easing function to be used for the transition.
+
+```es6
+Jump.jump('.selector', {
+  easing: (t, b, c, d) => {
+    return c * ( t /= d) * t + b
   }
 })
 ```

--- a/src/jump.js
+++ b/src/jump.js
@@ -1,3 +1,11 @@
+const easeInOutQuad = (t, b, c, d) => {
+  // Robert Penner's easeInOutQuad - http://robertpenner.com/easing/
+  t /= d / 2
+  if(t < 1) return c / 2 * t * t + b
+  t--
+  return -c / 2 * (t * (t - 2) - 1) + b
+}
+
 export default class Jump {
   jump(target, options = {}) {
     this.start = window.pageYOffset
@@ -5,7 +13,8 @@ export default class Jump {
     this.options = {
       duration: options.duration,
       offset: options.offset || 0,
-      callback: options.callback || undefined
+      callback: options.callback || undefined,
+      easing: options.easing || easeInOutQuad
     }
 
     this.distance = typeof target === 'string'
@@ -21,7 +30,7 @@ export default class Jump {
     }
 
     this.timeElapsed = time - this.timeStart
-    this.next = this._easing(this.timeElapsed, this.start, this.distance, this.options.duration)
+    this.next = this.options.easing(this.timeElapsed, this.start, this.distance, this.options.duration)
 
     window.scrollTo(0, this.next)
 
@@ -35,13 +44,5 @@ export default class Jump {
 
     typeof this.options.callback === 'function' && this.options.callback.call()
     this.timeStart = false
-  }
-
-  _easing(t, b, c, d) {
-    // Robert Penner's easeInOutQuad - http://robertpenner.com/easing/
-    t /= d / 2
-    if(t < 1) return c / 2 * t * t + b
-    t--
-    return -c / 2 * (t * (t - 2) - 1) + b
   }
 }


### PR DESCRIPTION
Someone suggested having more ease options baked in. I'm not sure it's something you want as the library would be heavier. Letting users specify the easing is still useful though:

``` es6
Jump.jump('.selector', {
  easing: (t, b, c, d) => {
    return c * ( t /= d) * t + b
  }
})
```
