### PR TITLE
Dynamically set duration based on distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Jump.jump('.selector', {
 })
 ```
 
+Or a function taking a `distance` argument (in px) and returning the duration (in milliseconds).
+
+```es6
+Jump.jump('.selector', {
+  duration: (distance) => Math.abs(distance)
+})
+```
+
 ##### offset
 
 Offset a `jump()`, _only if to an element_, in pixels.

--- a/src/jump.js
+++ b/src/jump.js
@@ -15,6 +15,10 @@ export default class Jump {
       ? this.options.offset + document.querySelector(target).getBoundingClientRect().top
       : target
 
+    this.duration = typeof this.options.duration === 'function'
+      ? parseInt(this.options.duration.call(null, this.distance), 10)
+      : this.options.duration
+
     requestAnimationFrame(time => this._loop(time))
   }
 
@@ -24,11 +28,11 @@ export default class Jump {
     }
 
     this.timeElapsed = time - this.timeStart
-    this.next = this.options.easing(this.timeElapsed, this.start, this.distance, this.options.duration)
+    this.next = this.options.easing(this.timeElapsed, this.start, this.distance, this.duration)
 
     window.scrollTo(0, this.next)
 
-    this.timeElapsed < this.options.duration
+    this.timeElapsed < this.duration
       ? requestAnimationFrame(time => this._loop(time))
       : this._end()
   }


### PR DESCRIPTION
Sometimes it is useful to have a duration proportional to the distance:

``` js
Jump.jump('.selector', {
  // 1ms for every 1px
  duration: (distance) => Math.abs(distance)
})
```
