### PR TITLE
removed unnecessary undefined

### DIFF
--- a/src/jump.js
+++ b/src/jump.js
@@ -7,7 +7,7 @@ export default class Jump {
     this.options = {
       duration: options.duration,
       offset: options.offset || 0,
-      callback: options.callback || undefined,
+      callback: options.callback,
       easing: options.easing || easeInOutQuad
     }
 


### PR DESCRIPTION
Since the whole code is so expressive I don't see any reason to add `|| undefined` since `options.callback` will evaluate to undefined if there is no `callback`
