### PR TITLE
Use babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
 
   "devDependencies": {
-    "babel":                           "*",
+    "babel-core":                      "*",
     "babel-preset-es2015":             "*",
     "babel-plugin-add-module-exports": "*",
     "babelify":                        "*",


### PR DESCRIPTION
This PR updates `package.json`, replacing the old `babel` package with the new `babel-core`.
