### PR TITLE
manual scroll will cancel jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Jump.jump('.selector', {
   duration: /* REQUIRED, no default */,
   offset: 0,
   callback: undefined,
+  scrollCancelJump: true,
   easing: (t, b, c, d) => {
     // Robert Penner's easeInOutQuad - http://robertpenner.com/easing/
     t /= d / 2
@@ -117,6 +118,16 @@ Useful for accomodating elements fixed to the top/bottom of the screen.
 ```es6
 Jump.jump('.selector', {
   offset: 100
+})
+```
+
+##### scrollCancelJump
+
+Manual scroll will cancel jump.
+
+```es6
+Jump.jump('.selector', {
+  scrollCancelJump: true
 })
 ```
 

--- a/src/jump.js
+++ b/src/jump.js
@@ -8,7 +8,8 @@ export default class Jump {
       duration: options.duration,
       offset: options.offset || 0,
       callback: options.callback,
-      easing: options.easing || easeInOutQuad
+      easing: options.easing || easeInOutQuad,
+      scrollCancelJump: options.scrollCancelJump
     }
 
     this.distance = typeof target === 'string'
@@ -30,17 +31,30 @@ export default class Jump {
     this.timeElapsed = time - this.timeStart
     this.next = this.options.easing(this.timeElapsed, this.start, this.distance, this.duration)
 
+    if (!!this.options.scrollCancelJump &&
+        !!this.lastScrollPosition &&
+          this.lastScrollPosition != window.scrollY) {
+      this._end()
+      return;
+    }
+
     window.scrollTo(0, this.next)
+
+    this.lastScrollPosition = window.scrollY
 
     this.timeElapsed < this.duration
       ? requestAnimationFrame(time => this._loop(time))
-      : this._end()
+      : this._lastStep()
+  }
+
+  _lastStep() {
+    window.scrollTo(0, this.start + this.distance)
+    this._end()
   }
 
   _end() {
-    window.scrollTo(0, this.start + this.distance)
-
     typeof this.options.callback === 'function' && this.options.callback()
+    this.lastScrollPosition = false
     this.timeStart = false
   }
 }


### PR DESCRIPTION
This is solution for issue #7 

I added new option: 

``` es6
Jump.jump('.selector', {
  scrollCancelJump: true
})
```

If `true` jump will be cancelled and user will be able to continue scrolling with the mouse or touchpad or whatever.
