### PR TITLE
Fixed error when using string as selector

### DIFF
--- a/src/jump.js
+++ b/src/jump.js
@@ -17,7 +17,7 @@ export default class Jump {
 
     this.distance = typeof target === 'number'
       ? target
-      : this.options.offset + target.getBoundingClientRect().top;
+      : this.options.offset + this.target.getBoundingClientRect().top;
 
     this.duration = typeof this.options.duration === 'function'
       ? this.options.duration(this.distance)


### PR DESCRIPTION
`this.target` should be used instead of `target`since it contains the DOM element whereas the parameter `target` can be a string, which leads to error.
In fact I ran into the error when using a string selector as the first parameter of `jump()`whereas everything is okay if you pass the element.
