### PR TITLE
fix(node.focus): preventing scroll on node.focus call

### DIFF
--- a/src/jump.js
+++ b/src/jump.js
@@ -70,7 +70,7 @@ const jumper = () => {
       element.setAttribute('tabindex', '-1')
 
       // focus the element
-      element.focus()
+      element.focus({ preventScroll: true })
     }
 
     // if it exists, fire the callback


### PR DESCRIPTION
Making sure the browser doesn't scroll to focused element, you might want to make this behavior optional, but for me - not scrolling seems like a better default here.

For now in my project, as a fallback I disabled a11y prop and I'm focusing it on my own in a custom callback:
`callback: () => {
  node.focus({ preventScroll: true });
},`

docs: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus