### PR TITLE
Scroll to element that are in bottom of the page

### DIFF
--- a/src/jump.js
+++ b/src/jump.js
@@ -32,7 +32,15 @@ const jumper = () => {
   // element offset helper
 
   function top (element) {
-    return element.getBoundingClientRect().top + start
+    // get max scroll value
+    const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+    const documentHeight = document.body.clientHeight;
+    const max = documentHeight - windowHeight - offset;
+
+    // get element scroll top
+    const top = element.getBoundingClientRect().top + start;
+    
+    return Math.min(element.getBoundingClientRect().top + start, max);
   }
 
   // rAF loop helper


### PR DESCRIPTION
Prevent a brutal stop animation if a targeted element is at the very bottom of the page.